### PR TITLE
支持多查询

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mutation update($form: User) {
   }
 }
 ```
-可以看到，我们通过 `#import` 引用了另外一个 `.gql` 文件 `fragment.gql`，在这个文件中我们描术了要返回的 user 的字段信息，这样我们就能在不同的地方「重用」它了，我们也创建一下这个文件
+可以看到，我们通过 `#import` 引用了另外一个 `.gql` 文件 `fragment.gql`，在这个文件中我们描述了要返回的 user 的字段信息，这样我们就能在不同的地方「重用」它了，我们也创建一下这个文件
 
 ```gql
 fragment userFields on User {
@@ -75,12 +75,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 async function query() {
-  const user = await user.get({ name: 'bob' });
-  console.log('user', user);
+  const userdata = await user.get({ name: 'bob' });
+  console.log('user', userdata);
 }
 
 async function update() {
-  const user = await user.update({ form: { age: 25 } })
+  const userdata = await user.update({ form: { age: 25 } })
+  console.log('after user', userdata);
 }
 
 function App() {

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yarn add gq-loader
 }
 ```
 
-然后，我们就可以在 `js` 文件中通过 `import` 来导入 `.gql` 文件使用它了，我们来一个简单的示例，假设已经有一个可以工作的 `Graphql Server`，那么，我们先创建一个可以用户的 `user.gql`
+然后，我们就可以在 `js` 文件中通过 `import` 来导入 `.gql` 文件使用它了，我们来一个简单的示例，假设已经有一个可以工作的 `Graphql Server`，那么，我们先创建一个用户的 `user.gql`
 
 ```graphql
 #import './fragment.gql' 

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,13 +1,24 @@
-import test from './test1.gql';
+import userGql from './test1.gql';
 import React from 'react';
 import ReactDOM from 'react-dom';
+console.log(userGql);
+async function query() {
+  const user = await userGql({ name: 'bob' });
+  console.log('user', user);
+}
 
-function query() {
-  test({ name: 0 });
+async function update() {
+  const user = await userGql.update({ form: { age: 25 } });
+  console.log('after update user:', user);
 }
 
 function App() {
-  return <button onClick={query}>click</button>;
+  return (
+    <div>
+      <button onClick={query}>query</button>
+      <button onClick={update}>update</button>
+    </div>
+  );
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/demo/test1.gql
+++ b/demo/test1.gql
@@ -1,7 +1,13 @@
 # import './test2.gql'  
 
-query MyTest {
-  user {
-    name   
+query get($name: String) {
+  getUser(name: $name) {
+    name
+  }
+}
+
+mutation update($form: User) {
+  updateUser(input: $form) {
+    ...test2
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,9 @@ const getDepFragments = (block, fragments) => {
   const deps = [];
 
   const loop = selection => {
+    if (!selection) {
+      return;
+    }
     if (selection.kind === 'FragmentSpread') {
       deps.push(fragments[selection.name.value]);
       loop(fragments[selection.name.value]);
@@ -143,7 +146,7 @@ var wrap = function(block, name){
       query: block, 
       variables: variables
     };
-    return request(url, data, options)
+    return (request.default || request)(url, data, options)
   }
   req.raw = block
   req.type = ~block.indexOf('mutation ') ? 'mutation' : 'query'

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,11 @@
 const path = require('path');
 const fs = require('fs');
 const _ = require('lodash');
-const os = require('os');
+const gql = require('graphql-tag');
+const { print } = require('graphql/language/printer');
 
 const IMPORT_REGEXP = /^#\s*(import|include|require)\s*(\'|\")(.+?)(\'|\")/;
 const EXTENSIONS = ['.gql', '.graphql'];
-const OPNAME_REGEXP = /(query|mutation) ?([\w\d-_]+)? ?\(.*?\)? \{/;
 
 function getFile(cwd, filePath, options, tryExts) {
   tryExts = (tryExts || options.extensions || []).slice(0);
@@ -45,11 +45,59 @@ function parse(cwd, source, options) {
   return _.uniq(contents);
 }
 
+const collect = (ast) => {
+  const collect = {
+    fragment: {},
+    query: {},
+    mutation: {},
+  };
+
+  ast.definitions.forEach(block => {
+    switch (block.kind) {
+      case 'FragmentDefinition':
+        collect.fragment[block.name.value] = block;
+        break;
+      case 'OperationDefinition':
+        collect[block.operation][block.name.value] = block;
+        break;
+      default:
+        break;
+    }
+  });
+
+  return collect;
+};
+
+const getDepFragments = (block, fragments) => {
+  const deps = [];
+
+  const loop = selection => {
+    if (selection.kind === 'FragmentSpread') {
+      deps.push(fragments[selection.name.value]);
+      loop(fragments[selection.name.value]);
+      return;
+    }
+    if (
+      selection.selectionSet && 
+      selection.selectionSet.selections && 
+      Array.isArray(selection.selectionSet.selections)
+    ) {
+      selection.selectionSet.selections.forEach(loop);
+    }
+  };
+
+  loop(block);
+
+  return deps;
+
+};
+
 function getOptions(ctx) {
   const options = ctx.loaders[ctx.loaderIndex].options || {};
   return _.defaults(options, {
     extensions: EXTENSIONS,
     string: false,
+    debug: false,
     url: '/graphql',
     request: require.resolve('./request')
   });
@@ -59,24 +107,64 @@ function loader(source) {
   this.cacheable();
   const options = getOptions(this);
   const result = parse.call(this, this.context, source, options);
-  const query = JSON.stringify(result.join(os.EOL));
-  const opnameInfo = OPNAME_REGEXP.exec(query);
-  const operationName = JSON.stringify((opnameInfo && opnameInfo[2]) || '');
+  const query = result.join('\n');
+  const ast = gql(query);
+
+  const col = collect(ast);
+
+  const blocks = {};
+  const debugBlock = {};
+
+  let length = 0;
+  _.each(Object.assign({}, col.query, col.mutation), (block, key) => {
+    length++;
+    const depFragments = getDepFragments(block, col.fragment).concat(block);
+
+    blocks[key] = print(depFragments).join('\n');
+    if (options.debug) {
+      debugBlock[key] = depFragments;
+    }
+  });
+  
   if (options.string) {
-    return `module.exports = ${query}`;
-  } else {
-    return `
-    var request = require('${options.request}');
-    var url = '${options.url}';
-    module.exports = function(variables, options) {
-      var data = { 
-        operationName: ${operationName},
-        query: ${query}, 
-        variables: JSON.stringify(variables)
-      };
-      return request(url, data, options);
-    };`
+    return `module.exports = ${JSON.stringify(length === 1 ? Object.values(blocks).pop() : blocks)}`;
   }
+
+
+
+  let output = `
+var request = require('${options.request}');
+var url = '${options.url}';
+var blocks = ${JSON.stringify(blocks)}
+var wrap = function(block, name){
+  var req = function(variables, options) {
+    var data = { 
+      operationName: name,
+      query: block, 
+      variables: variables
+    };
+    return request(url, data, options)
+  }
+  req.raw = block
+  req.type = ~block.indexOf('mutation ') ? 'mutation' : 'query'
+  return req
+}
+var exportBlock = {} 
+var length = 0
+for(var key in blocks) {
+  length++
+  exportBlock[key] = wrap(blocks[key], key)
+}
+exportBlock._raw = Object.values(blocks)
+exportBlock._debug = ${options.debug ? JSON.stringify(debugBlock) : false}
+if (length === 1) {
+  // if only one, just export for compatible
+  module.exports = Object.values(exportBlock).shift()
+} else {
+  module.exports = exportBlock;
+}
+`;
+  return output;
 }
 
 module.exports = loader;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.17.1"
+    "axios": "^0.17.1",
+    "graphql": "^14.2.1",
+    "graphql-tag": "^2.10.1"
   },
   "devDependencies": {
     "react": "^16.2.0",


### PR DESCRIPTION
感谢原作者提供这么好的设计思路，由于原本并不支持在一个 `gql` 文件中定义多个操作，会在使用过程中有诸多不方便，故进一步优化支持在一个文件中定义多个操作

支持多个查询，export 是一个对象

* key 是 operationName，在一个文件中不能重复，在不同文件可重复
* value 是可直接执行的查询函数，机制和原有 request 一致

如果配置中 `string: true`，则 value 是graphql 查询语句，并已自动修复 fragment 的依赖问题

> 为了向下兼容，如果查询语句只有一个，则导出的是可直接执行的函数，和原来一致